### PR TITLE
Fix wrong constant for Preview in the OMTVideoFlags enum

### DIFF
--- a/libomt.h
+++ b/libomt.h
@@ -138,7 +138,7 @@ typedef enum OMTVideoFlags
     OMTVideoFlags_Interlaced = 1,
     OMTVideoFlags_Alpha = 2,
     OMTVideoFlags_PreMultiplied = 4,
-    OMTVideoFlags_Preview = 4,
+    OMTVideoFlags_Preview = 8,
     OMTVideoFlags_HighBitDepth = 16,
     OMTVideoFlags_INT32 = 0x7fffffff //Ensure int type in C
 } OMTVideoFlags;


### PR DESCRIPTION
The value `4` is used twice in the `OMTVideoFlags` enum. The [protocol documentation](https://github.com/openmediatransport/libomtnet/blob/master/PROTOCOL.md) lists the correct value as 8 here.