### PR TITLE
Exposed logging callback to native library to intercept log lines

### DIFF
--- a/libomt.h
+++ b/libomt.h
@@ -336,6 +336,7 @@ typedef struct OMTMediaFrame
 
 typedef long long omt_receive_t;
 typedef long long omt_send_t;
+typedef void (*OMTLoggingCallback)(const char *);
 
 #ifdef __cplusplus
 extern "C" {
@@ -549,6 +550,11 @@ extern "C" {
     * To override the default folder used for for logs, set the OMT_STORAGE_PATH environment variable prior to calling any OMT functions.
     */
     void omt_setloggingfilename(const char* filename);
+
+    /**
+    * Specify a log line callback, or null to disable.
+    */
+    void omt_setloggingcallback(OMTLoggingCallback callback);
 
     /**
     * =================================================

--- a/src/libomt.cs
+++ b/src/libomt.cs
@@ -597,6 +597,23 @@ namespace libomt
             }
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "omt_setloggingcallback")]
+        public static void OMTSetLoggingCallback(IntPtr callback)
+        {
+            if (callback != IntPtr.Zero)
+            {
+                OMTLogging.LogCallbackDelegate? fn = Marshal.GetDelegateForFunctionPointer<OMTLogging.LogCallbackDelegate>(callback);
+                if (fn != null)
+                {
+                    OMTLogging.SetCallback(fn);
+                }
+            }
+            else
+            {
+                OMTLogging.SetCallback(null);
+            }
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "omt_discovery_getaddresses")]
         private static IntPtr OMTDiscoveryGetAddresses(IntPtr addressCount)
         {


### PR DESCRIPTION
This adds `omt_setloggingcallback` to allow a native client to specify a callback to receive log lines in order to forward to a custom logger. 